### PR TITLE
Make `amf0::read::parse_single_element` public

### DIFF
--- a/flash-lso/src/amf0/read.rs
+++ b/flash-lso/src/amf0/read.rs
@@ -136,7 +136,7 @@ fn read_type_marker(i: &[u8]) -> AMFResult<'_, TypeMarker> {
     ))
 }
 
-fn parse_single_element(i: &[u8]) -> AMFResult<'_, Value> {
+pub fn parse_single_element(i: &[u8]) -> AMFResult<'_, Value> {
     let (i, type_) = read_type_marker(i)?;
 
     match type_ {

--- a/flash-lso/src/amf0/read.rs
+++ b/flash-lso/src/amf0/read.rs
@@ -136,6 +136,7 @@ fn read_type_marker(i: &[u8]) -> AMFResult<'_, TypeMarker> {
     ))
 }
 
+/// Parse a single AMF0 element
 pub fn parse_single_element(i: &[u8]) -> AMFResult<'_, Value> {
     let (i, type_) = read_type_marker(i)?;
 

--- a/flash-lso/src/lib.rs
+++ b/flash-lso/src/lib.rs
@@ -1,6 +1,6 @@
 //! Library for reading and writing the Adobe Flash Local Shared Object (LSO) file format and the contained AMF0/AMF3 data
 
-#![warn(
+#![deny(
     anonymous_parameters,
     nonstandard_style,
     rust_2018_idioms,


### PR DESCRIPTION
This makes sense because `AMF3Decoder::parse_single_element` is also public, and they are convenient to be able to use