### PR TITLE
dev: set nom to 6.* for use in ruffle

### DIFF
--- a/flash-lso/Cargo.toml
+++ b/flash-lso/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["data-structures", "encoding", "parser-implementations"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "6.2.0"
+nom = "6.*"
 cookie-factory = "0.3.2"
 derive-try-from-primitive = "1.0.0"
 enumset = { version = "1.0.6", features = ["serde"] }


### PR DESCRIPTION
ruffle requires 6.1 through winit. Expanding the allowed range to 6.* fixes this problem.

The error is:
```
error: failed to select a version for `nom`.
    ... required by package `flash-lso v0.5.0 (https://github.com/ruffle-rs/rust-flash-lso#a0a32715)`
    ... which is depended on by `ruffle_core v0.1.0 (/home/me/ruffle/core)`
    ... which is depended on by `exporter v0.1.0 (/home/me/ruffle/exporter)`
versions that meet the requirements `^6.2.0` are: 6.2.1, 6.2.0

all possible versions conflict with previously selected packages.

  previously selected package `nom v6.1.2`
    ... which is depended on by `xcursor v0.3.3`
    ... which is depended on by `wayland-cursor v0.28.6`
    ... which is depended on by `smithay-client-toolkit v0.12.3`
    ... which is depended on by `winit v0.25.0`
    ... which is depended on by `ruffle_desktop v0.1.0 (/home/me/ruffle/desktop)`

failed to select a version for `nom` which could resolve this conflict
```