### PR TITLE
Web fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cargo fuzz run --release fuzz_amf3_body
 ## Web
 building:
 ```
-wasm-pack build --out-name wasm --out-dir ./static --target web --release
+wasm-pack build --out-name web --out-dir ./static --target web --release
 miniserve ./static --index index.html
 ```
 

--- a/web/src/component_model.rs
+++ b/web/src/component_model.rs
@@ -139,8 +139,8 @@ impl Component for Model {
                 }
             }
             Msg::Selection(val) => {
-                if self.current_selection.as_ref().map(|ev| ev.value.clone())
-                    == Some(val.value.clone())
+                if self.current_selection.as_ref().map(|ev| ev.path.clone())
+                    == Some(val.path.clone())
                 {
                     self.current_selection = None;
                 } else {

--- a/web/src/component_model.rs
+++ b/web/src/component_model.rs
@@ -656,7 +656,7 @@ impl Model {
     }
 
     fn view_file(&self, ctx: &Context<Self>, _index: usize, data: &Lso) -> Html {
-        let root_class = "text-white bg-primary rounded-pill pl-2 pr-2";
+        let root_class = "text-white bg-primary rounded-pill pl-2 pr-2 user-select-none";
 
         html! {
             <div class="container-fluid">

--- a/web/src/component_tabs.rs
+++ b/web/src/component_tabs.rs
@@ -48,7 +48,7 @@ impl Component for Tabs {
                       { for ctx.props().children.iter().enumerate().map(|(i, e)| html! {
                          <li class="nav-item" role="tablist">
                             <span class={format!("nav-link {}", if ctx.props().selected == Some(i) {"active"} else {""})} role="tab" onclick={ctx.link().callback(move |_| Msg::Selected(i))}>
-                                <a href="_blank" style="vertical-align: middle;">{&e.props.label}</a>{ self.tab_details(ctx, e, i) }
+                                <a href="#" style="vertical-align: middle;">{&e.props.label}</a>{ self.tab_details(ctx, e, i) }
                              </span>
                          </li>
                       })}

--- a/web/src/component_treenode.rs
+++ b/web/src/component_treenode.rs
@@ -125,9 +125,9 @@ impl Component for TreeNode {
         };
 
         let classes = if self.selected(ctx) {
-            "text-white bg-primary rounded-pill pl-2 pr-2"
+            "text-white bg-primary rounded-pill pl-2 pr-2 user-select-none"
         } else {
-            "pl-2 pr-2"
+            "pl-2 pr-2 user-select-none"
         };
 
         let callback = ctx.link().callback(Msg::Edited);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Yew Sample App</title>
+  <title>LSO Editor</title>
 
   <script src="script/jquery.min.js"></script>
   <link rel="stylesheet" href="css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">


### PR DESCRIPTION
Some minor fixes for the web editor:
- Change the app name to "LSO Editor"
- Fix the build command in the readme
- Fix tab links (they should not open a new browser tab)
- Prevent selecting text in tree nodes. This makes it feel less janky
- Compare node paths instead of values when changing selection. Before this fix, selecting an item with the same value as the currently selected item was treated as deselecting the first item.