### PR TITLE
Group updates to web dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
         patterns:
           - "yew"
 
+      web:
+        patterns:
+          - web-sys
+          - js-sys
+          - wasm-bindgen
+
       cargo-minor:
         patterns:
           - "*"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -11,9 +11,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 yew = { version = "=0.23.0", features = ["csr"] }
-web-sys = "=0.3.95"
-wasm-bindgen = "=0.2.118"
-js-sys = "=0.3.95"
+web-sys = "=0.3.99"
+wasm-bindgen = "=0.2.122"
+js-sys = "=0.3.99"
 log = "=0.4.29"
 wasm-logger = "=0.2.0"
 flash-lso = { path = "../flash-lso", features = ["serde", "flex"] }


### PR DESCRIPTION
Make sure that `web-sys`, `js-sys` and `wasm-bindgen` in the `web` project are bumped together. This should hopefully resolve the CI failures from dependabot prs.