### PR TITLE
amf0: Add TypedObject writer

### DIFF
--- a/flash-lso/src/amf0/writer/amf0_writer.rs
+++ b/flash-lso/src/amf0/writer/amf0_writer.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, rc::Rc};
 
 use crate::types::{AMFVersion, Element, Lso, Reference, Value};
 
-use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter};
+use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter, TypedObjectWriter};
 
 /// A writer for Amf0 encoded data
 #[derive(Default)]
@@ -76,6 +76,37 @@ impl<'a> ObjWriter<'a> for Amf0Writer {
             // Return the writer and the reference
             (
                 Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn typed_object<'c: 'a, 'd>(
+        &'d mut self,
+        class_name: &str,
+        cache_key: CacheKey,
+    ) -> (Option<TypedObjectWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache.get(&cache_key) {
+            (None, *existing_ref)
+        } else {
+            // Create new typed object reference
+            let r = Reference(self.ref_num);
+            self.ref_num += 1;
+
+            // Cache this new typed object
+            self.cache.insert(cache_key, r);
+
+            // Return the writer and the reference
+            (
+                Some(TypedObjectWriter {
+                    class_name: class_name.to_string(),
                     elements: Vec::new(),
                     parent: self,
                 }),

--- a/flash-lso/src/amf0/writer/array_writer.rs
+++ b/flash-lso/src/amf0/writer/array_writer.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::types::{Element, ObjectId, Reference, Value};
 
-use super::{CacheKey, ObjWriter, ObjectWriter};
+use super::{CacheKey, ObjWriter, ObjectWriter, TypedObjectWriter};
 
 /// A writer for encoding `ECMAArray` contents
 pub struct ArrayWriter<'a, 'b> {
@@ -69,6 +69,35 @@ impl<'a> ObjWriter<'a> for ArrayWriter<'a, '_> {
             // Return the writer and the reference
             (
                 Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn typed_object<'c: 'a, 'd>(
+        &'d mut self,
+        class_name: &str,
+        cache_key: CacheKey,
+    ) -> (Option<TypedObjectWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            // Cache this new typed object
+            self.cache_add(cache_key, r);
+
+            // Return the writer and the reference
+            (
+                Some(TypedObjectWriter {
+                    class_name: class_name.to_string(),
                     elements: Vec::new(),
                     parent: self,
                 }),

--- a/flash-lso/src/amf0/writer/mod.rs
+++ b/flash-lso/src/amf0/writer/mod.rs
@@ -3,12 +3,14 @@ mod array_writer;
 mod cache_key;
 mod obj_writer;
 mod object_writer;
+mod typed_object_writer;
 
 pub use amf0_writer::Amf0Writer;
 pub use array_writer::ArrayWriter;
 pub use cache_key::CacheKey;
 pub use obj_writer::ObjWriter;
 pub use object_writer::ObjectWriter;
+pub use typed_object_writer::TypedObjectWriter;
 
 #[test]
 fn fff() {

--- a/flash-lso/src/amf0/writer/obj_writer.rs
+++ b/flash-lso/src/amf0/writer/obj_writer.rs
@@ -1,6 +1,6 @@
 use crate::types::{Reference, Value};
 
-use super::{ArrayWriter, CacheKey, ObjectWriter};
+use super::{ArrayWriter, CacheKey, ObjectWriter, TypedObjectWriter};
 
 /// A trait of common functions between writers
 pub trait ObjWriter<'a> {
@@ -30,7 +30,20 @@ pub trait ObjWriter<'a> {
     where
         'a: 'c,
         'a: 'd;
-    //Typed objects can also be sent cached
+
+    /// Typed objects can also be sent cached
+    /// Create a writer that can serialize a typed object
+    ///
+    /// If an object with the same `cache_key` has already been written, then this will return `None` for the Writer and the existing reference
+    /// If this key is unique, then both a Writer and a Reference will be returned
+    fn typed_object<'c: 'a, 'd>(
+        &'d mut self,
+        class_name: &str,
+        cache_key: CacheKey,
+    ) -> (Option<TypedObjectWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd;
 
     /// Write a string
     fn string(&mut self, name: &str, s: &str) {

--- a/flash-lso/src/amf0/writer/typed_object_writer.rs
+++ b/flash-lso/src/amf0/writer/typed_object_writer.rs
@@ -1,11 +1,14 @@
 use std::rc::Rc;
 
-use crate::types::{Element, ObjectId, Reference, Value};
+use crate::types::{ClassDefinition, Element, ObjectId, Reference, Value};
 
-use super::{ArrayWriter, CacheKey, ObjWriter, TypedObjectWriter};
+use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter};
 
-/// A writer for encoding the contents of a child object
-pub struct ObjectWriter<'a, 'b> {
+/// A writer for encoding the contents of a typed child object
+pub struct TypedObjectWriter<'a, 'b> {
+    /// The class name/alias of this typed object
+    pub(crate) class_name: String,
+
     /// The elements of this object
     pub(crate) elements: Vec<Element>,
 
@@ -13,7 +16,7 @@ pub struct ObjectWriter<'a, 'b> {
     pub(crate) parent: &'a mut dyn ObjWriter<'b>,
 }
 
-impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
+impl<'a> ObjWriter<'a> for TypedObjectWriter<'a, '_> {
     fn add_element(&mut self, name: &str, s: Value, inc_ref: bool) {
         if inc_ref {
             self.parent.make_reference();
@@ -89,11 +92,7 @@ impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
             (None, existing_ref)
         } else {
             let r = self.make_reference();
-
-            // Cache this new typed object
             self.cache_add(cache_key, r);
-
-            // Return the writer and the reference
             (
                 Some(TypedObjectWriter {
                     class_name: class_name.to_string(),
@@ -118,14 +117,18 @@ impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
     }
 }
 
-impl ObjectWriter<'_, '_> {
-    /// Finalize this object, adding it to it's parent
+impl TypedObjectWriter<'_, '_> {
+    /// Finalize this typed object, adding it to its parent
     /// If this is not called, the object will not be added
     pub fn commit<T: AsRef<str>>(self, name: T) {
-        //TODO: this doent work for multi level nesting
+        //TODO: this doesn't work for multi level nesting
         self.parent.add_element(
             name.as_ref(),
-            Value::Object(ObjectId::INVALID, self.elements, None),
+            Value::Object(
+                ObjectId::INVALID,
+                self.elements,
+                Some(ClassDefinition::default_with_name(self.class_name)),
+            ),
             false,
         );
     }


### PR DESCRIPTION
## Description

Per https://github.com/ruffle-rs/ruffle/issues/16356#issuecomment-2994243907 it seems like NetDebugConfig is meant to be a TypedObject with a class definition, whereas right now it's a plain object without a class definition. I think this is needed for that.

## Testing

To be added

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have added or updated tests where possible.
- [x] This PR builds, has no outstanding failing lints, and passes all tests.
- [x] An LLM was NOT involved in the authoring of this code.
