### PR TITLE
Add strict array amf0 writer

### DIFF
--- a/flash-lso/src/amf0/writer/amf0_writer.rs
+++ b/flash-lso/src/amf0/writer/amf0_writer.rs
@@ -78,6 +78,34 @@ impl<'a> ObjWriter<'a> for Amf0Writer {
                 Some(ArrayWriter {
                     elements: Vec::new(),
                     parent: self,
+                    is_strict: false,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache.get(&cache_key) {
+            (None, *existing_ref)
+        } else {
+            let r = Reference(self.ref_num);
+            self.ref_num += 1;
+
+            self.cache.insert(cache_key, r);
+
+            (
+                Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                    is_strict: true,
                 }),
                 r,
             )

--- a/flash-lso/src/amf0/writer/array_writer.rs
+++ b/flash-lso/src/amf0/writer/array_writer.rs
@@ -11,6 +11,9 @@ pub struct ArrayWriter<'a, 'b> {
 
     /// The parent of this writer
     pub(crate) parent: &'a mut dyn ObjWriter<'b>,
+
+    /// Tracks if this writes a Strict Array (0x0A) or an ECMA Array (0x08)
+    pub(crate) is_strict: bool,
 }
 
 impl<'a> ObjWriter<'a> for ArrayWriter<'a, '_> {
@@ -71,6 +74,33 @@ impl<'a> ObjWriter<'a> for ArrayWriter<'a, '_> {
                 Some(ArrayWriter {
                     elements: Vec::new(),
                     parent: self,
+                    is_strict: false,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            self.cache_add(cache_key, r);
+
+            (
+                Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                    is_strict: true,
                 }),
                 r,
             )
@@ -123,10 +153,17 @@ impl ArrayWriter<'_, '_> {
     /// Finalize this array, adding it to it's parent
     /// If this is not called, the array will not be added
     pub fn commit<T: AsRef<str>>(self, name: T, length: u32) {
-        self.parent.add_element(
-            name.as_ref(),
-            Value::ECMAArray(ObjectId::INVALID, Vec::new(), self.elements, length),
-            false,
-        );
+        let value = if self.is_strict {
+            let strict_elements = self
+                .elements
+                .into_iter()
+                .map(|e| e.value)
+                .collect::<Vec<Rc<Value>>>();
+
+            Value::StrictArray(ObjectId::INVALID, strict_elements)
+        } else {
+            Value::ECMAArray(ObjectId::INVALID, Vec::new(), self.elements, length)
+        };
+        self.parent.add_element(name.as_ref(), value, false);
     }
 }

--- a/flash-lso/src/amf0/writer/obj_writer.rs
+++ b/flash-lso/src/amf0/writer/obj_writer.rs
@@ -19,11 +19,23 @@ pub trait ObjWriter<'a> {
         'a: 'c,
         'a: 'd;
 
-    /// Create a writer that can serialize an array
+    /// Create a writer that can serialize an ECMA array (0x08)
     ///
     /// If an object with the same `cache_key` has already been written, then this will return `None` for the Writer and the existing reference
     /// If this key is unique, then both a Writer and a Reference will be returned
     fn array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd;
+
+    /// Create a writer that can serialize a dense, keyless strict array (0x0A)
+    ///
+    /// If an object with the same `cache_key` has already been written, then this will return `None` for the Writer and the existing reference
+    /// If this key is unique, then both a Writer and a Reference will be returned
+    fn strict_array<'c: 'a, 'd>(
         &'d mut self,
         cache_key: CacheKey,
     ) -> (Option<ArrayWriter<'d, 'c>>, Reference)

--- a/flash-lso/src/amf0/writer/object_writer.rs
+++ b/flash-lso/src/amf0/writer/object_writer.rs
@@ -70,6 +70,33 @@ impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
                 Some(ArrayWriter {
                     elements: Vec::new(),
                     parent: self,
+                    is_strict: false,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            self.cache_add(cache_key, r);
+
+            (
+                Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                    is_strict: true,
                 }),
                 r,
             )

--- a/flash-lso/src/amf0/writer/typed_object_writer.rs
+++ b/flash-lso/src/amf0/writer/typed_object_writer.rs
@@ -73,6 +73,31 @@ impl<'a> ObjWriter<'a> for TypedObjectWriter<'a, '_> {
                 Some(ArrayWriter {
                     elements: Vec::new(),
                     parent: self,
+                    is_strict: false,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+            self.cache_add(cache_key, r);
+            (
+                Some(ArrayWriter {
+                    elements: Vec::new(),
+                    parent: self,
+                    is_strict: true,
                 }),
                 r,
             )


### PR DESCRIPTION
## Description

Add a boolean to the array writer for AMF0 saying if the array is strict or not. If so, it writes a StrictArray instead of an ECMAArray.

I can fully understand why this wasn't done initially - AMF0 doesn't encode anything as a StrictArray when it comes to SharedObjects. However, Ruffle now uses rust-flash-lso for Flash Remoting as well, and when doing Flash remoting with AMF0, Flash will encode some arrays as StrictArray.

## Testing

https://github.com/ruffle-rs/ruffle/pull/24049

## Checklist

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have added or updated tests where possible.
- [x] This PR builds, has no outstanding failing lints, and passes all tests.
- [ ] An LLM was NOT involved in the authoring of this code.
