### PR TITLE
Add StrictArrayWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ wasm-pack build --out-name web --out-dir ./static --target web --release
 miniserve ./static --index index.html
 ```
 
+## LLM policy
+Please ensure all contributions to this project are conducted with respect to our [LLM policy](https://nlnetlabs.nl/llm-policy/)
+
 ## License
 This project is licensed under MIT.
 

--- a/flash-lso/src/amf0/writer/amf0_writer.rs
+++ b/flash-lso/src/amf0/writer/amf0_writer.rs
@@ -1,6 +1,6 @@
-use std::{collections::BTreeMap, rc::Rc};
-
+use crate::amf0::writer::strict_array_writer::StrictArrayWriter;
 use crate::types::{AMFVersion, Element, Lso, Reference, Value};
+use std::{collections::BTreeMap, rc::Rc};
 
 use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter, TypedObjectWriter};
 
@@ -77,6 +77,33 @@ impl<'a> ObjWriter<'a> for Amf0Writer {
             (
                 Some(ArrayWriter {
                     elements: Vec::new(),
+                    parent: self,
+                }),
+                r,
+            )
+        }
+    }
+
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<StrictArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            // Cache this new array
+            self.cache_add(cache_key, r);
+
+            // Return the writer and the reference
+            (
+                Some(StrictArrayWriter {
+                    values: Vec::new(),
                     parent: self,
                 }),
                 r,

--- a/flash-lso/src/amf0/writer/array_writer.rs
+++ b/flash-lso/src/amf0/writer/array_writer.rs
@@ -1,6 +1,6 @@
-use std::rc::Rc;
-
+use crate::amf0::writer::strict_array_writer::StrictArrayWriter;
 use crate::types::{Element, ObjectId, Reference, Value};
+use std::rc::Rc;
 
 use super::{CacheKey, ObjWriter, ObjectWriter, TypedObjectWriter};
 
@@ -77,6 +77,33 @@ impl<'a> ObjWriter<'a> for ArrayWriter<'a, '_> {
         }
     }
 
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<StrictArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            // Cache this new array
+            self.cache_add(cache_key, r);
+
+            // Return the writer and the reference
+            (
+                Some(StrictArrayWriter {
+                    values: Vec::new(),
+                    parent: self,
+                }),
+                r,
+            )
+        }
+    }
+
     fn typed_object<'c: 'a, 'd>(
         &'d mut self,
         class_name: &str,
@@ -120,7 +147,7 @@ impl<'a> ObjWriter<'a> for ArrayWriter<'a, '_> {
 }
 
 impl ArrayWriter<'_, '_> {
-    /// Finalize this array, adding it to it's parent
+    /// Finalise this array, adding it to it's parent
     /// If this is not called, the array will not be added
     pub fn commit<T: AsRef<str>>(self, name: T, length: u32) {
         self.parent.add_element(

--- a/flash-lso/src/amf0/writer/mod.rs
+++ b/flash-lso/src/amf0/writer/mod.rs
@@ -3,6 +3,7 @@ mod array_writer;
 mod cache_key;
 mod obj_writer;
 mod object_writer;
+mod strict_array_writer;
 mod typed_object_writer;
 
 pub use amf0_writer::Amf0Writer;

--- a/flash-lso/src/amf0/writer/obj_writer.rs
+++ b/flash-lso/src/amf0/writer/obj_writer.rs
@@ -1,3 +1,4 @@
+use crate::amf0::writer::strict_array_writer::StrictArrayWriter;
 use crate::types::{Reference, Value};
 
 use super::{ArrayWriter, CacheKey, ObjectWriter, TypedObjectWriter};
@@ -27,6 +28,18 @@ pub trait ObjWriter<'a> {
         &'d mut self,
         cache_key: CacheKey,
     ) -> (Option<ArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd;
+
+    /// Create a writer that can serialize a strict array
+    ///
+    /// If an object with the same `cache_key` has already been written, then this will return `None` for the Writer and the existing reference
+    /// If this key is unique, then both a Writer and a Reference will be returned
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<StrictArrayWriter<'d, 'c>>, Reference)
     where
         'a: 'c,
         'a: 'd;
@@ -80,7 +93,7 @@ pub trait ObjWriter<'a> {
         self.add_element(name, Value::Date(ms, tz), true)
     }
 
-    /// Write a XML
+    /// Write an XML
     fn xml(&mut self, name: &str, v: &str, s: bool) {
         self.add_element(name, Value::XML(v.to_string(), s), true);
     }

--- a/flash-lso/src/amf0/writer/strict_array_writer.rs
+++ b/flash-lso/src/amf0/writer/strict_array_writer.rs
@@ -1,25 +1,25 @@
-use crate::amf0::writer::strict_array_writer::StrictArrayWriter;
-use crate::types::{Element, ObjectId, Reference, Value};
 use std::rc::Rc;
 
-use super::{ArrayWriter, CacheKey, ObjWriter, TypedObjectWriter};
+use crate::types::{ObjectId, Reference, Value};
 
-/// A writer for encoding the contents of a child object
-pub struct ObjectWriter<'a, 'b> {
-    /// The elements of this object
-    pub(crate) elements: Vec<Element>,
+use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter, TypedObjectWriter};
+
+/// A writer for encoding `StrictArray` contents
+pub struct StrictArrayWriter<'a, 'b> {
+    /// The values in this array
+    pub(crate) values: Vec<Rc<Value>>,
 
     /// The parent of this writer
     pub(crate) parent: &'a mut dyn ObjWriter<'b>,
 }
 
-impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
-    fn add_element(&mut self, name: &str, s: Value, inc_ref: bool) {
+impl<'a> ObjWriter<'a> for StrictArrayWriter<'a, '_> {
+    fn add_element(&mut self, _name: &str, s: Value, inc_ref: bool) {
         if inc_ref {
-            self.parent.make_reference();
+            self.make_reference();
         }
 
-        self.elements.push(Element::new(name, Rc::new(s)));
+        self.values.push(Rc::new(s));
     }
 
     fn object<'c: 'a, 'd>(
@@ -145,14 +145,13 @@ impl<'a> ObjWriter<'a> for ObjectWriter<'a, '_> {
     }
 }
 
-impl ObjectWriter<'_, '_> {
-    /// Finalise this object, adding it to it's parent
-    /// If this is not called, the object will not be added
+impl StrictArrayWriter<'_, '_> {
+    /// Finalise this array, adding it to it's parent
+    /// If this is not called, the array will not be added
     pub fn commit<T: AsRef<str>>(self, name: T) {
-        //TODO: this doesn't work for multi level nesting
         self.parent.add_element(
             name.as_ref(),
-            Value::Object(ObjectId::INVALID, self.elements, None),
+            Value::StrictArray(ObjectId::INVALID, self.values),
             false,
         );
     }

--- a/flash-lso/src/amf0/writer/typed_object_writer.rs
+++ b/flash-lso/src/amf0/writer/typed_object_writer.rs
@@ -1,6 +1,6 @@
-use std::rc::Rc;
-
+use crate::amf0::writer::strict_array_writer::StrictArrayWriter;
 use crate::types::{ClassDefinition, Element, ObjectId, Reference, Value};
+use std::rc::Rc;
 
 use super::{ArrayWriter, CacheKey, ObjWriter, ObjectWriter};
 
@@ -79,6 +79,33 @@ impl<'a> ObjWriter<'a> for TypedObjectWriter<'a, '_> {
         }
     }
 
+    fn strict_array<'c: 'a, 'd>(
+        &'d mut self,
+        cache_key: CacheKey,
+    ) -> (Option<StrictArrayWriter<'d, 'c>>, Reference)
+    where
+        'a: 'c,
+        'a: 'd,
+    {
+        if let Some(existing_ref) = self.cache_get(&cache_key) {
+            (None, existing_ref)
+        } else {
+            let r = self.make_reference();
+
+            // Cache this new array
+            self.cache_add(cache_key, r);
+
+            // Return the writer and the reference
+            (
+                Some(StrictArrayWriter {
+                    values: Vec::new(),
+                    parent: self,
+                }),
+                r,
+            )
+        }
+    }
+
     fn typed_object<'c: 'a, 'd>(
         &'d mut self,
         class_name: &str,
@@ -118,7 +145,7 @@ impl<'a> ObjWriter<'a> for TypedObjectWriter<'a, '_> {
 }
 
 impl TypedObjectWriter<'_, '_> {
-    /// Finalize this typed object, adding it to its parent
+    /// Finalise this typed object, adding it to its parent
     /// If this is not called, the object will not be added
     pub fn commit<T: AsRef<str>>(self, name: T) {
         //TODO: this doesn't work for multi level nesting

--- a/lso-to-json/Cargo.toml
+++ b/lso-to-json/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT"
 
 [dependencies]
 flash-lso = { path = "../flash-lso", features = ["serde", "flex"] }
-env_logger = "=0.11.10"
+env_logger = "=0.11.11"
 clap = "=4.6.1"
 serde_json = "=1.0.150"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 yew = { version = "=0.23.0", features = ["csr"] }
-web-sys = "=0.3.99"
-wasm-bindgen = "=0.2.122"
-js-sys = "=0.3.99"
+web-sys = "=0.3.103"
+wasm-bindgen = "=0.2.126"
+js-sys = "=0.3.103"
 log = "=0.4.33"
 wasm-logger = "=0.2.0"
 flash-lso = { path = "../flash-lso", features = ["serde", "flex"] }


### PR DESCRIPTION
## Description

See #111 and #113.

Given that these two writers produce distinctly different `Value` types they should use different `ObjWriter` implementations, rather than making `ArrayWriter` dual purpose. Only API difference here is the lack of a useless `length` parameter on `commit` for `StrictArrayWriter`

## Checklist

<!-- 
Please check that this PR meets our baseline for an acceptable contribution.
Note that this repository currently does not accept LLM generated contributions.
-->

- [x] I, a human, have self-reviewed this PR and fully understand the changes within.
- [ ] I have added or updated tests where possible.
- [x] This PR builds, has no outstanding failing lints, and passes all tests.
- [x] An LLM was NOT involved in the authoring of this code.
