### PR TITLE
Fix reference slot accounting and property emission in the AMF3 writer

### DIFF
--- a/flash-lso/src/amf3/element_cache.rs
+++ b/flash-lso/src/amf3/element_cache.rs
@@ -32,6 +32,17 @@ impl<T: PartialEq + Clone + Debug> ElementCache<T> {
         }
     }
 
+    /// Take the next cache slot for the given item, without deduplicating, and return its index.
+    ///
+    /// A reader allocates one slot per value it decodes, so the writer must too: deduplicating
+    /// would collapse two distinct values into one slot and skew every later reference index.
+    #[inline]
+    pub(crate) fn occupy(&self, val: T) -> usize {
+        let mut cache = self.cache.borrow_mut();
+        cache.push(val);
+        cache.len() - 1
+    }
+
     /// Retrieve the item at the given index from the cache
     #[inline]
     pub fn get_element(&self, index: usize) -> Option<T> {

--- a/flash-lso/src/amf3/length.rs
+++ b/flash-lso/src/amf3/length.rs
@@ -16,13 +16,6 @@ impl Length {
         matches!(self, Length::Size(_))
     }
 
-    pub(crate) fn as_position(&self) -> Option<usize> {
-        match self {
-            Length::Reference(x) => Some(*x),
-            _ => None,
-        }
-    }
-
     pub(crate) fn write<'a, 'b: 'a, W: Write + 'a>(
         &self,
         writer: &mut W,

--- a/flash-lso/src/amf3/write.rs
+++ b/flash-lso/src/amf3/write.rs
@@ -150,23 +150,17 @@ impl AMF3Encoder {
         items: &'b [i32],
         fixed_length: bool,
     ) -> Result<()> {
-        let len = self.object_reference_table.to_length(
-            Value::VectorInt(VectorPrimitiveValue {
+        self.object_reference_table
+            .occupy(Value::VectorInt(VectorPrimitiveValue {
                 values: items.to_vec(),
                 fixed_length,
-            }),
-            items.len() as u32,
-        );
+            }));
 
         self.write_type_marker(writer, TypeMarker::VectorInt)?;
-        if len.is_reference() {
-            len.write(writer, self)?;
-        } else {
-            Length::Size(items.len() as u32).write(writer, self)?;
-            writer.write_u8(fixed_length as u8)?;
-            for item in items {
-                writer.write_i32(*item)?;
-            }
+        Length::Size(items.len() as u32).write(writer, self)?;
+        writer.write_u8(fixed_length as u8)?;
+        for item in items {
+            writer.write_i32(*item)?;
         }
         Ok(())
     }
@@ -177,23 +171,17 @@ impl AMF3Encoder {
         items: &'b [u32],
         fixed_length: bool,
     ) -> Result<()> {
-        let len = self.object_reference_table.to_length(
-            Value::VectorUInt(VectorPrimitiveValue {
+        self.object_reference_table
+            .occupy(Value::VectorUInt(VectorPrimitiveValue {
                 values: items.to_vec(),
                 fixed_length,
-            }),
-            items.len() as u32,
-        );
+            }));
 
         self.write_type_marker(writer, TypeMarker::VectorUInt)?;
-        if len.is_reference() {
-            len.write(writer, self)?;
-        } else {
-            Length::Size(items.len() as u32).write(writer, self)?;
-            writer.write_u8(fixed_length as u8)?;
-            for item in items {
-                writer.write_u32(*item)?;
-            }
+        Length::Size(items.len() as u32).write(writer, self)?;
+        writer.write_u8(fixed_length as u8)?;
+        for item in items {
+            writer.write_u32(*item)?;
         }
         Ok(())
     }
@@ -204,23 +192,17 @@ impl AMF3Encoder {
         items: &'b [f64],
         fixed_length: bool,
     ) -> Result<()> {
-        let len = self.object_reference_table.to_length(
-            Value::VectorDouble(VectorPrimitiveValue {
+        self.object_reference_table
+            .occupy(Value::VectorDouble(VectorPrimitiveValue {
                 values: items.to_vec(),
                 fixed_length,
-            }),
-            items.len() as u32,
-        );
+            }));
 
         self.write_type_marker(writer, TypeMarker::VectorDouble)?;
-        if len.is_reference() {
-            len.write(writer, self)?;
-        } else {
-            Length::Size(items.len() as u32).write(writer, self)?;
-            writer.write_u8(fixed_length as u8)?;
-            for item in items {
-                writer.write_f64(*item)?;
-            }
+        Length::Size(items.len() as u32).write(writer, self)?;
+        writer.write_u8(fixed_length as u8)?;
+        for item in items {
+            writer.write_f64(*item)?;
         }
         Ok(())
     }
@@ -230,19 +212,14 @@ impl AMF3Encoder {
         writer: &mut W,
         time: f64,
     ) -> Result<()> {
-        let len = self.object_reference_table.to_length(
-            Value::Date {
-                time,
-                timezone_or_utc: None,
-            },
-            0,
-        );
+        self.object_reference_table.occupy(Value::Date {
+            time,
+            timezone_or_utc: None,
+        });
 
         self.write_type_marker(writer, TypeMarker::Date)?;
-        len.write(writer, self)?;
-        if len.is_size() {
-            writer.write_f64(time)?;
-        }
+        Length::Size(0).write(writer, self)?;
+        writer.write_f64(time)?;
         Ok(())
     }
 
@@ -261,15 +238,12 @@ impl AMF3Encoder {
         writer: &mut W,
         bytes: &'b [u8],
     ) -> Result<()> {
-        let len = self
-            .object_reference_table
-            .to_length(Value::ByteArray(bytes.to_vec()), bytes.len() as u32);
+        self.object_reference_table
+            .occupy(Value::ByteArray(bytes.to_vec()));
 
         self.write_type_marker(writer, TypeMarker::ByteArray)?;
-        len.write(writer, self)?;
-        if len.is_size() {
-            writer.write_all(bytes)?;
-        }
+        Length::Size(bytes.len() as u32).write(writer, self)?;
+        writer.write_all(bytes)?;
         Ok(())
     }
 
@@ -279,7 +253,10 @@ impl AMF3Encoder {
         bytes: &'b str,
         string: bool,
     ) -> Result<()> {
-        let len = Length::Size(bytes.len() as u32);
+        self.object_reference_table.occupy(Value::XML {
+            value: bytes.to_string(),
+            is_string: string,
+        });
 
         if string {
             self.write_type_marker(writer, TypeMarker::XmlString)?;
@@ -287,10 +264,8 @@ impl AMF3Encoder {
             self.write_type_marker(writer, TypeMarker::Xml)?;
         }
 
-        len.write(writer, self)?;
-        if len.is_size() {
-            writer.write_all(bytes.as_bytes())?;
-        }
+        Length::Size(bytes.len() as u32).write(writer, self)?;
+        writer.write_all(bytes.as_bytes())?;
         Ok(())
     }
 
@@ -306,7 +281,66 @@ impl AMF3Encoder {
         Ok(())
     }
 
-    //TODO: conds should be common somehwere
+    /// The external representation of an externalizable object, via its registered encoder.
+    fn write_external_body<'a, 'b: 'a, W: Write + 'a>(
+        &'a self,
+        writer: &mut W,
+        custom_props: Option<&'b [Element]>,
+        def: &'b ClassDefinition,
+    ) -> Result<()> {
+        let encoder = self.external_encoders.get(&def.name).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("no encoder registered for external class \"{}\"", def.name),
+            )
+        })?;
+        let custom_props = custom_props.ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "externalizable value of class \"{}\" has no external elements",
+                    def.name
+                ),
+            )
+        })?;
+        writer.write_all(&encoder.encode(custom_props, &Some(def.clone()), self))
+    }
+
+    /// The sealed property values of an object, in the order its traits declare them, followed
+    /// by the dynamic section if the traits are dynamic.
+    fn write_object_properties<'a, 'b: 'a, W: Write + 'a>(
+        &'a self,
+        writer: &mut W,
+        children: &'b [Element],
+        def: &'b ClassDefinition,
+    ) -> Result<()> {
+        for name in &def.static_properties {
+            let child = children.iter().find(|c| &c.name == name).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "object of class \"{}\" has no value for static property \"{}\"",
+                        def.name, name
+                    ),
+                )
+            })?;
+            self.write_value_element(writer, &child.value)?;
+        }
+
+        if def.attributes.contains(Attribute::Dynamic) {
+            for c in children
+                .iter()
+                .filter(|c| !def.static_properties.contains(&c.name))
+            {
+                self.write_byte_string(writer, c.name.as_bytes())?;
+                self.write_value_element(writer, &c.value)?;
+            }
+            self.write_byte_string(writer, &[])?;
+        }
+
+        Ok(())
+    }
+
     fn write_trait_reference<'a, 'b: 'a, W: Write + 'a>(
         &'a self,
         writer: &mut W,
@@ -320,42 +354,11 @@ impl AMF3Encoder {
 
         self.write_int(writer, size as i32)?;
         if def.attributes.contains(Attribute::External) {
-            if let Some(encoder) = self.external_encoders.get(&def.name) {
-                writer.write_all(&encoder.encode(
-                    custom_props.expect("Custom encoder, missing custom props"),
-                    &Some(def.clone()),
-                    self,
-                ))?;
-            } else {
-                unimplemented!();
-            }
+            self.write_external_body(writer, custom_props, def)?;
         }
 
         if !def.attributes.contains(Attribute::External) {
-            if def.attributes.is_empty() {
-                for c in children {
-                    if def.static_properties.contains(&c.name) {
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-            }
-
-            if def.attributes.contains(Attribute::Dynamic) {
-                for c in children {
-                    if def.static_properties.contains(&c.name) {
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-
-                for c in children {
-                    if !def.static_properties.contains(&c.name) {
-                        self.write_byte_string(writer, c.name.as_bytes())?;
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-
-                self.write_byte_string(writer, &[])?;
-            }
+            self.write_object_properties(writer, children, def)?;
         }
         Ok(())
     }
@@ -399,39 +402,10 @@ impl AMF3Encoder {
         self.write_int(writer, size as i32)?;
         self.write_class_definition(writer, def)?;
         if def.attributes.contains(Attribute::External) {
-            if let Some(encoder) = self.external_encoders.get(&def.name) {
-                writer.write_all(&encoder.encode(
-                    custom_props.expect("Custom encode but missing custom props"),
-                    &Some(def.clone()),
-                    self,
-                ))?;
-            } else {
-                unimplemented!();
-            }
+            self.write_external_body(writer, custom_props, def)?;
         }
         if !def.attributes.contains(Attribute::External) {
-            if def.attributes.is_empty() {
-                for c in children {
-                    if def.static_properties.contains(&c.name) {
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-            }
-
-            if def.attributes.contains(Attribute::Dynamic) {
-                for c in children {
-                    if def.static_properties.contains(&c.name) {
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-                for c in children {
-                    if !def.static_properties.contains(&c.name) {
-                        self.write_byte_string(writer, c.name.as_bytes())?;
-                        self.write_value_element(writer, &c.value)?;
-                    }
-                }
-                self.write_byte_string(writer, &[])?;
-            }
+            self.write_object_properties(writer, children, def)?;
         }
         Ok(())
     }
@@ -454,11 +428,11 @@ impl AMF3Encoder {
                 class_definition: class_def.clone(),
             },
         };
-        self.object_reference_table.store(obj.clone());
-        if let Length::Reference(r) = self.object_reference_table.to_length(obj, 0) {
+        let slot = self.object_reference_table.occupy(obj);
+        if id != ObjectId::INVALID {
             self.object_id_to_reference
                 .borrow_mut()
-                .insert(id, (TypeMarker::Object, r));
+                .insert(id, (TypeMarker::Object, slot));
         }
 
         let def = class_def.clone().unwrap_or_default();
@@ -471,15 +445,9 @@ impl AMF3Encoder {
             .position(|cd| *cd == def);
 
         self.write_type_marker(writer, TypeMarker::Object)?;
-        if had_object.is_reference() {
-            self.write_object_reference(
-                writer,
-                had_object
-                    .as_position()
-                    .expect("Failed to convert to position") as u32,
-            )?;
-        }
-        if !had_object.is_reference() {
+        if let Length::Reference(r) = had_object {
+            self.write_object_reference(writer, r as u32)?;
+        } else {
             if let Some(has_trait) = has_trait {
                 self.write_trait_reference(
                     writer,
@@ -568,11 +536,11 @@ impl AMF3Encoder {
         let len = self
             .object_reference_table
             .to_length(vo.clone(), items.len() as u32);
-        self.object_reference_table.store(vo.clone());
-        if let Length::Reference(r) = self.object_reference_table.to_length(vo, 0) {
+        let slot = self.object_reference_table.occupy(vo);
+        if id != ObjectId::INVALID {
             self.object_id_to_reference
                 .borrow_mut()
-                .insert(id, (TypeMarker::VectorObject, r));
+                .insert(id, (TypeMarker::VectorObject, slot));
         }
 
         self.write_type_marker(writer, TypeMarker::VectorObject)?;
@@ -605,11 +573,11 @@ impl AMF3Encoder {
         let len = self
             .object_reference_table
             .to_length(dict.clone(), items.len() as u32);
-        self.object_reference_table.store(dict.clone());
-        if let Length::Reference(r) = self.object_reference_table.to_length(dict, 0) {
+        let slot = self.object_reference_table.occupy(dict);
+        if id != ObjectId::INVALID {
             self.object_id_to_reference
                 .borrow_mut()
-                .insert(id, (TypeMarker::Dictionary, r));
+                .insert(id, (TypeMarker::Dictionary, slot));
         }
 
         self.write_type_marker(writer, TypeMarker::Dictionary)?;
@@ -647,21 +615,21 @@ impl AMF3Encoder {
             Value::Null => self.write_null_element(writer),
             Value::Undefined => self.write_undefined_element(writer),
             Value::ECMAArray { id, data } => {
-                self.object_reference_table.store(s.clone());
-                if let Length::Reference(r) = self.object_reference_table.to_length(s.clone(), 0) {
+                let slot = self.object_reference_table.occupy(s.clone());
+                if *id != ObjectId::INVALID {
                     self.object_id_to_reference
                         .borrow_mut()
-                        .insert(*id, (TypeMarker::Array, r));
+                        .insert(*id, (TypeMarker::Array, slot));
                 }
 
                 self.write_ecma_array_element(writer, &data.dense, &data.elements)
             }
             Value::StrictArray { id, values } => {
-                self.object_reference_table.store(s.clone());
-                if let Length::Reference(r) = self.object_reference_table.to_length(s.clone(), 0) {
+                let slot = self.object_reference_table.occupy(s.clone());
+                if *id != ObjectId::INVALID {
                     self.object_id_to_reference
                         .borrow_mut()
-                        .insert(*id, (TypeMarker::Array, r));
+                        .insert(*id, (TypeMarker::Array, slot));
                 }
 
                 self.write_strict_array_element(writer, values)
@@ -696,13 +664,18 @@ impl AMF3Encoder {
             ),
             Value::AMF3(e) => self.write_value_element(writer, e),
             Value::Unsupported => self.write_undefined_element(writer),
-            Value::Reference(_) => unimplemented!(),
+            Value::Reference(_) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "AMF0 reference in an AMF3 stream",
+            )),
             Value::Amf3ObjectReference(id) => {
-                let (ty, r) = *self
-                    .object_id_to_reference
-                    .borrow()
-                    .get(id)
-                    .expect("Invalid reference");
+                let entry = self.object_id_to_reference.borrow().get(id).copied();
+                let (ty, r) = entry.ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("unresolvable AMF3 object reference {id:?}"),
+                    )
+                })?;
                 self.write_type_marker(writer, ty)?;
                 self.write_object_reference(writer, r as u32)
             }
@@ -767,5 +740,219 @@ mod write_number_tests {
         let mut v = Vec::new();
         e.write_int(&mut v, -268435455).expect("Test fail");
         assert_eq!(v, &[192, 128, 128, 1]);
+    }
+}
+
+#[cfg(test)]
+mod write_property_tests {
+    use crate::amf3::write::AMF3Encoder;
+    use crate::types::{Attribute, ClassDefinition, Element, ObjectId, ObjectValue, Value};
+
+    fn class(
+        name: &str,
+        props: &[&str],
+        attributes: enumset::EnumSet<Attribute>,
+    ) -> ClassDefinition {
+        ClassDefinition {
+            name: name.to_string(),
+            attributes,
+            static_properties: props.iter().map(|p| p.to_string()).collect(),
+        }
+    }
+
+    fn object(def: ClassDefinition, children: Vec<Element>) -> Value {
+        Value::Object {
+            id: ObjectId(1),
+            data: ObjectValue {
+                elements: children,
+                class_definition: Some(def),
+            },
+        }
+    }
+
+    fn int(name: &str, v: i32) -> Element {
+        Element {
+            name: name.to_string(),
+            value: Value::Integer(v),
+        }
+    }
+
+    /// Sealed values follow the order the traits declare, not the order the children happen to
+    /// be in, or a reader assigns them to the wrong properties.
+    #[test]
+    fn sealed_values_follow_trait_order() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        e.write_value_element(
+            &mut v,
+            &object(
+                class("C", &["a", "b"], Default::default()),
+                vec![int("b", 2), int("a", 1)],
+            ),
+        )
+        .expect("Test fail");
+
+        // ...traits, "C", "a", "b", then the values for a and b in that order.
+        assert_eq!(&v[v.len() - 4..], &[0x04, 0x01, 0x04, 0x02]);
+    }
+
+    /// A duplicate sealed name must not emit two values for one declared property.
+    #[test]
+    fn duplicate_sealed_names_emit_one_value_each() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        e.write_value_element(
+            &mut v,
+            &object(
+                class("C", &["a"], Default::default()),
+                vec![int("a", 1), int("a", 9)],
+            ),
+        )
+        .expect("Test fail");
+
+        assert_eq!(&v[v.len() - 2..], &[0x04, 0x01]);
+    }
+
+    /// A declared property with no value cannot be silently skipped: that truncates the object.
+    #[test]
+    fn missing_sealed_value_errors() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        assert!(
+            e.write_value_element(
+                &mut v,
+                &object(
+                    class("C", &["a", "b"], Default::default()),
+                    vec![int("a", 1)]
+                ),
+            )
+            .is_err()
+        );
+    }
+
+    /// Children whose names are declared sealed must not be repeated in the dynamic section.
+    #[test]
+    fn dynamic_section_excludes_sealed_names() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        e.write_value_element(
+            &mut v,
+            &object(
+                class("C", &["a"], Attribute::Dynamic.into()),
+                vec![int("a", 1), int("d", 2)],
+            ),
+        )
+        .expect("Test fail");
+
+        // value of a, then "d" (utf8-vr len 1) + its value, then the empty terminator.
+        assert_eq!(
+            &v[v.len() - 7..],
+            &[0x04, 0x01, 0x03, b'd', 0x04, 0x02, 0x01]
+        );
+    }
+}
+
+#[cfg(test)]
+mod write_reference_tests {
+    use crate::amf3::write::AMF3Encoder;
+    use crate::types::{ObjectId, ObjectValue, Value};
+
+    fn empty_object(id: i64) -> Value {
+        Value::Object {
+            id: ObjectId(id),
+            data: ObjectValue {
+                elements: Vec::new(),
+                class_definition: None,
+            },
+        }
+    }
+
+    /// A conformant reader allocates a reference slot for every Date, so an object written after
+    /// one sits at slot 1 and a back-reference to it must encode as index 1.
+    #[test]
+    fn payload_values_occupy_a_reference_slot() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+
+        e.write_value_element(
+            &mut v,
+            &Value::Date {
+                time: 0.0,
+                timezone_or_utc: None,
+            },
+        )
+        .expect("Test fail");
+        e.write_value_element(&mut v, &empty_object(7))
+            .expect("Test fail");
+
+        let mut r = Vec::new();
+        e.write_value_element(&mut r, &Value::Amf3ObjectReference(ObjectId(7)))
+            .expect("Test fail");
+
+        assert_eq!(r, &[0x0a, 0x02]);
+    }
+
+    /// Equal payloads must not collapse into one slot: Value carries no identity for them, so
+    /// each occurrence takes its own.
+    #[test]
+    fn equal_payload_values_take_separate_slots() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+
+        for _ in 0..3 {
+            e.write_value_element(&mut v, &Value::ByteArray(vec![1, 2, 3]))
+                .expect("Test fail");
+        }
+        e.write_value_element(&mut v, &empty_object(9))
+            .expect("Test fail");
+
+        let mut r = Vec::new();
+        e.write_value_element(&mut r, &Value::Amf3ObjectReference(ObjectId(9)))
+            .expect("Test fail");
+
+        assert_eq!(r, &[0x0a, 0x06]);
+    }
+
+    /// Objects that compare equal must still take separate slots. Every `Value::Custom` is
+    /// written with `ObjectId::INVALID`, so two externalizable values of one class are equal;
+    /// deduplicating them would skew every later reference index.
+    #[test]
+    fn equal_objects_take_separate_slots() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+
+        for _ in 0..2 {
+            e.write_value_element(&mut v, &empty_object(ObjectId::INVALID.0))
+                .expect("Test fail");
+        }
+        e.write_value_element(&mut v, &empty_object(5))
+            .expect("Test fail");
+
+        let mut r = Vec::new();
+        e.write_value_element(&mut r, &Value::Amf3ObjectReference(ObjectId(5)))
+            .expect("Test fail");
+
+        assert_eq!(r, &[0x0a, 0x04]);
+    }
+
+    #[test]
+    fn unresolvable_object_reference_errors() {
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        assert!(
+            e.write_value_element(&mut v, &Value::Amf3ObjectReference(ObjectId(1)))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn amf0_reference_in_an_amf3_stream_errors() {
+        use crate::types::Reference;
+        let e = AMF3Encoder::default();
+        let mut v = Vec::new();
+        assert!(
+            e.write_value_element(&mut v, &Value::Reference(Reference(0)))
+                .is_err()
+        );
     }
 }


### PR DESCRIPTION
## Description

The AMF3 writer deduplicated values when assigning object-reference-table slots, but a conformant reader allocates one slot per value it decodes.
Two equal values (identical ByteArrays, two externalizable objects of the same class, …) collapsed into a single slot on the write side, skewing every later reference index. XML values reserved no slot at all. The writer also had property-emission bugs: sealed values were written in children order rather than the order the traits declare, a child with no value for a declared property was silently skipped (truncating the object), and duplicate names could emit twice.

## Testing

I've added tests (made an LLM do them so i guess it counts as LLM usage? hopefully this will be recognized as repetitive work and will be exempt from the no LLM policy 🙏 )

## Checklist

<!-- 
Please check that this PR meets our baseline for an acceptable contribution.
Note that this repository currently does not accept LLM generated contributions.
-->

- [X] I, a human, have self-reviewed this PR and fully understand the changes within.
- [X] I have added or updated tests where possible.
- [X] This PR builds, has no outstanding failing lints, and passes all tests.
- [X] An LLM was NOT involved in the authoring of this code.
